### PR TITLE
Explicitly transform edma packages for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,10 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@edma\/(design-tokens|blocks))"
+    ]
   }
 }


### PR DESCRIPTION
Jest does not automatically transform files within `node_modules` before test. This change ensures the edma packages `blocks` and `design-tokens` are whitelisted and explicitly transformed during testing in order to prevent ESM / CJS compatibility issues.