### PR TITLE
Fix: page wrapper and routing re-org

### DIFF
--- a/src/Components/Presentational/Chrome/Navigation.js
+++ b/src/Components/Presentational/Chrome/Navigation.js
@@ -12,8 +12,6 @@ import RequestListItem from '../../Scenes/SideNavigation/RequestListItem/Request
 import KeysListItem from '../../Scenes/SideNavigation/KeysListItem/KeysListItem';
 import AwsAthenaListItem from '../../Scenes/SideNavigation/AwsAthenaListItem/AwsAthenaListItem';
 import AvatarListItem from '../../Scenes/SideNavigation/AvatarListItem/AvatarListItem';
-import RequestAssetsContainer from '../../Scenes/RequestAssets/RequestAsset/RequestAsset-Container';
-import { Switch, Route } from 'react-router-dom';
 
 const navWidth = 250;
 
@@ -100,10 +98,7 @@ const Navigation = () => {
         <AvatarListItem />
       </Drawer>
       <main>
-        <Switch>
-          <Route exact path="/" component={PageWrapper} />
-          <Route path="/RequestAsset" component={RequestAssetsContainer} />
-        </Switch>
+        <PageWrapper />
       </main>
     </div>
   );

--- a/src/Components/Scenes/Chrome/AppBar/AppBar.js
+++ b/src/Components/Scenes/Chrome/AppBar/AppBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ThemeToggle from '../../../Presentational/Chrome/ThemeToggle';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
-import SearchModal from '../SearchModal/SearchModal-Container';
+import SearchButton from '../SearchButton/SearchButton-Container';
 import color from '@edma/design-tokens/js/color';
 import { ReactComponent as KirbyLogo } from '../../../../assets/img/kirbyLogo.svg';
 
@@ -11,7 +11,7 @@ const appBarStyle = makeStyles(theme => ({
     marginLeft: '16px',
     display: 'flex'
   },
-  searchModal: {
+  searchButton: {
     position: 'absolute',
     right: '104px',
     top: '-2px'
@@ -43,8 +43,8 @@ const Appbar = props => {
       <div className={classes.logoContainer}>
         <KirbyLogo className={classes.Logo} />
       </div>
-      <div className={classes.searchModal}>
-        <SearchModal />
+      <div className={classes.searchButton}>
+        <SearchButton />
       </div>
       <div className={classes.themeToggleContainer}>
         <ThemeToggle />

--- a/src/Components/Scenes/Chrome/PageWrapper/PageWrapper-Container.js
+++ b/src/Components/Scenes/Chrome/PageWrapper/PageWrapper-Container.js
@@ -3,9 +3,6 @@ import PageWrapper from './PageWrapper';
 
 const mapStateToProps = ({ searchResult }) => {
   return {
-    searchResultCopy: searchResult.searchResultCopy,
-    isLoading: searchResult.isLoading,
-    displaySearchResult: searchResult.displaySearchResult,
     isSearchClicked: searchResult.isSearchClicked,
     isSearchClosed: searchResult.isSearchClosed
   };

--- a/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
+++ b/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
 import AppBarContainer from '../AppBar/AppBar-Container';
 import Splash from '../../../Presentational/Splash';
 import { makeStyles } from '@material-ui/core/styles';
 import color from '@edma/design-tokens/js/color';
-import TableSectionContainer from '../../SearchResults/TableSection/TableSection-Container';
-import TableSkeleton from '../../SearchResults/TableSkeleton/TableSkeleton';
 import SearchContainer from '../Search/Search-Container';
+import SearchResultsContainer from '../../SearchResults/SearchResults/SearchResults-Container';
 
 const pageContainerStyle = makeStyles(theme => ({
   pageContainer: {
@@ -19,23 +19,18 @@ const pageContainerStyle = makeStyles(theme => ({
   }
 }));
 
-const PageWrapper = props => {
-  const {
-    searchResultCopy,
-    isLoading,
-    displaySearchResult,
-    isSearchClicked
-  } = props;
+const PageWrapper = ({ isSearchClicked }) => {
   const classes = pageContainerStyle();
+
   return (
     <div className={classes.pageContainer}>
       <AppBarContainer />
-      {isLoading ? (
-        <TableSkeleton />
-      ) : displaySearchResult ? (
-        <TableSectionContainer />
-      ) : null}
-      {!searchResultCopy.length > 0 ? <Splash /> : null}
+
+      <Switch>
+        <Route exact path="/" component={Splash} />
+        <Route path="/Search" component={SearchResultsContainer} />
+      </Switch>
+
       {isSearchClicked ? <SearchContainer /> : null}
     </div>
   );

--- a/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
+++ b/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
@@ -6,6 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import color from '@edma/design-tokens/js/color';
 import SearchContainer from '../Search/Search-Container';
 import SearchResultsContainer from '../../SearchResults/SearchResults/SearchResults-Container';
+import RequestAssetContainer from '../../RequestAssets/RequestAsset/RequestAsset-Container';
 
 const pageContainerStyle = makeStyles(theme => ({
   pageContainer: {
@@ -28,7 +29,12 @@ const PageWrapper = ({ isSearchClicked }) => {
 
       <Switch>
         <Route exact path="/" component={Splash} />
-        <Route path="/Search" component={SearchResultsContainer} />
+        <Route exact path="/search" component={SearchResultsContainer} />
+        <Route path="/search/access" component={RequestAssetContainer} />
+        <Route
+          path="/requests/archive"
+          component={null /* will implement later */}
+        />
       </Switch>
 
       {isSearchClicked ? <SearchContainer /> : null}

--- a/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
+++ b/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
@@ -29,12 +29,13 @@ const PageWrapper = ({ isSearchClicked }) => {
 
       <Switch>
         <Route exact path="/" component={Splash} />
+        {/* search pages */}
         <Route exact path="/search" component={SearchResultsContainer} />
         <Route path="/search/access" component={RequestAssetContainer} />
-        <Route
-          path="/requests/archive"
-          component={null /* will implement later */}
-        />
+        {/* requests pages - will be implemented and hooked in soon */}
+        <Route exact path="/requests" component={null} />
+        <Route path="/requests/archive" component={null} />
+        <Route path="/requests/sent" component={null} />
       </Switch>
 
       {isSearchClicked ? <SearchContainer /> : null}

--- a/src/Components/Scenes/Chrome/Search/Search.js
+++ b/src/Components/Scenes/Chrome/Search/Search.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
   Button,
   TextField,
@@ -40,7 +41,12 @@ const SearchInput = props => {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => searchResultRequest()} color="primary">
+          <Button
+            onClick={() => searchResultRequest()}
+            color="primary"
+            component={Link}
+            to="Search"
+          >
             Close
           </Button>
         </DialogActions>

--- a/src/Components/Scenes/Chrome/Search/Search.js
+++ b/src/Components/Scenes/Chrome/Search/Search.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import {
   Button,
   TextField,
@@ -18,6 +18,16 @@ const SearchInput = props => {
     handleKeyPress,
     isSearchClicked
   } = props;
+
+  const history = useHistory();
+
+  const keyPressWrapper = e => {
+    if (e.key === 'Enter') {
+      searchResultRequest();
+      history.push('/search');
+    }
+  };
+
   return (
     <React.Fragment>
       <Dialog open={isSearchClicked} aria-labelledby="form-dialog-title">
@@ -35,9 +45,7 @@ const SearchInput = props => {
             value={searchInput}
             onChange={e => searchHandleInput(e)}
             fullWidth
-            onKeyPress={e =>
-              handleKeyPress(e.key === 'Enter' ? searchResultRequest() : null)
-            }
+            onKeyPress={e => handleKeyPress(keyPressWrapper(e))}
           />
         </DialogContent>
         <DialogActions>
@@ -45,7 +53,7 @@ const SearchInput = props => {
             onClick={() => searchResultRequest()}
             color="primary"
             component={Link}
-            to="Search"
+            to="/search"
           >
             Close
           </Button>

--- a/src/Components/Scenes/Chrome/SearchButton/SearchButton-Container.js
+++ b/src/Components/Scenes/Chrome/SearchButton/SearchButton-Container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { handleSearchClick } from '../../../../Actions/searchResultActions';
-import SearchModal from './SearchModal';
+import SearchButton from './SearchButton';
 
 const mapDispatchToProps = dispatch => {
   return {
@@ -8,4 +8,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(null, mapDispatchToProps)(SearchModal);
+export default connect(null, mapDispatchToProps)(SearchButton);

--- a/src/Components/Scenes/Chrome/SearchButton/SearchButton.js
+++ b/src/Components/Scenes/Chrome/SearchButton/SearchButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import { makeStyles, IconButton } from '@material-ui/core';
 
-const searchModalStyles = makeStyles(theme => ({
+const searchButtonStyles = makeStyles(theme => ({
   iconButton: {
     position: 'absolute',
     right: 0,
@@ -10,9 +10,9 @@ const searchModalStyles = makeStyles(theme => ({
   }
 }));
 
-const SearchModal = props => {
+const SearchButton = props => {
   const { handleSearchClick } = props;
-  const classes = searchModalStyles();
+  const classes = searchButtonStyles();
 
   return (
     <div>
@@ -27,4 +27,4 @@ const SearchModal = props => {
   );
 };
 
-export default SearchModal;
+export default SearchButton;

--- a/src/Components/Scenes/RequestAssets/RequestAsset/RequestAsset-Container.js
+++ b/src/Components/Scenes/RequestAssets/RequestAsset/RequestAsset-Container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import RequestTable from './RequestAsset';
+import RequestAsset from './RequestAsset';
 
 const mapStateToProps = state => {
   return {
@@ -7,4 +7,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(RequestTable);
+export default connect(mapStateToProps)(RequestAsset);

--- a/src/Components/Scenes/RequestAssets/RequestAsset/RequestAsset.js
+++ b/src/Components/Scenes/RequestAssets/RequestAsset/RequestAsset.js
@@ -1,23 +1,12 @@
 import React from 'react';
 import RequestAssetTableContainer from '../RequestAssetTable/RequestAssetTable-Container';
 import RequestAssetJustificationContainer from '../RequestAssetJustification/RequestAssetJustification-Container';
-import AppBarContainer from '../../Chrome/AppBar/AppBar-Container';
 import { makeStyles } from '@material-ui/core/styles';
-import color from '@edma/design-tokens/js/color';
 
 const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap'
-  },
-  pageContainer: {
-    position: 'absolute',
-    display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: theme.palette.type === 'light' ? 'dark' : 'light',
-    width: '100%',
-    height: '100vh',
-    color: color.white
   },
   sideTable: {
     width: '62%',
@@ -39,16 +28,13 @@ const RequestAsset = () => {
   const classes = useStyles();
   return (
     <>
-      <div className={classes.pageContainer}>
-        <AppBarContainer />
-        <div className={classes.sideTable}>
-          <RequestAssetTableContainer />
-          <RequestAssetJustificationContainer />
-        </div>
-        <div className="sidebar">
-          <div className={classes.sideBarPostion}>
-            <h1>Request Assets</h1>
-          </div>
+      <div className={classes.sideTable}>
+        <RequestAssetTableContainer />
+        <RequestAssetJustificationContainer />
+      </div>
+      <div className="sidebar">
+        <div className={classes.sideBarPostion}>
+          <h1>Request Assets</h1>
         </div>
       </div>
     </>

--- a/src/Components/Scenes/SearchResults/CheckBoxButton/CheckBoxButton.js
+++ b/src/Components/Scenes/SearchResults/CheckBoxButton/CheckBoxButton.js
@@ -16,24 +16,24 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const CheckBoxButton = props => {
-  const classes = useStyles();
   const { searchResultCopy, requestAssetsClick } = props;
+  const classes = useStyles();
   const searchResultChecked = searchResultCopy.filter(obj => obj.checked);
-  const searchResultLenght = searchResultChecked.length;
+  const searchResultLength = searchResultChecked.length;
   const buttonText =
-    searchResultLenght === 1
-      ? `Request ${searchResultLenght} Asset`
-      : searchResultLenght > 1
-      ? `Request ${searchResultLenght} Assets`
+    searchResultLength === 1
+      ? `Request ${searchResultLength} Asset`
+      : searchResultLength > 1
+      ? `Request ${searchResultLength} Assets`
       : 'Request Asset';
 
   return (
     <>
-      <Link to="/RequestAsset" className={classes.underline}>
+      <Link to="/search/access" className={classes.underline}>
         <Button
           color="primary"
           variant="contained"
-          disabled={searchResultLenght <= 0}
+          disabled={searchResultLength <= 0}
           className={classes.button}
           onClick={() => requestAssetsClick(searchResultChecked)}
         >

--- a/src/Components/Scenes/SearchResults/SearchResults/SearchResults-Container.js
+++ b/src/Components/Scenes/SearchResults/SearchResults/SearchResults-Container.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import SearchResults from './SearchResults';
+
+const mapStateToProps = ({ searchResult }) => {
+  return {
+    searchResultCopy: searchResult.searchResultCopy,
+    isLoading: searchResult.isLoading,
+    displaySearchResult: searchResult.displaySearchResult
+  };
+};
+
+export default connect(mapStateToProps)(SearchResults);

--- a/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
+++ b/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Splash from '../../../Presentational/Splash';
+import TableSectionContainer from '../../SearchResults/TableSection/TableSection-Container';
+import TableSkeleton from '../../SearchResults/TableSkeleton/TableSkeleton';
+
+const searchResultsStyle = makeStyles(theme => ({
+  // not certain if we will want or need separate styles at the moment
+  searchResults: {}
+}));
+
+const SearchResults = ({
+  searchResultCopy,
+  isLoading,
+  displaySearchResult
+}) => {
+  const classes = searchResultsStyle();
+
+  return (
+    <div className={classes.searchResults}>
+      {isLoading ? (
+        <TableSkeleton />
+      ) : displaySearchResult ? (
+        <TableSectionContainer />
+      ) : null}
+      {!searchResultCopy.length ? <Splash /> : null}
+    </div>
+  );
+};
+
+export default SearchResults;

--- a/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
+++ b/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
@@ -1,30 +1,22 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
 import Splash from '../../../Presentational/Splash';
 import TableSectionContainer from '../../SearchResults/TableSection/TableSection-Container';
 import TableSkeleton from '../../SearchResults/TableSkeleton/TableSkeleton';
-
-const searchResultsStyle = makeStyles(theme => ({
-  // not certain if we will want or need separate styles at the moment
-  searchResults: {}
-}));
 
 const SearchResults = ({
   searchResultCopy,
   isLoading,
   displaySearchResult
 }) => {
-  const classes = searchResultsStyle();
-
   return (
-    <div className={classes.searchResults}>
+    <>
       {isLoading ? (
         <TableSkeleton />
       ) : displaySearchResult ? (
         <TableSectionContainer />
       ) : null}
       {!searchResultCopy.length ? <Splash /> : null}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
* Moving the router `<Switch>` into the `<PageWrapper>` component - hopefully a good home for future development and organization
* Extracting search results into their own new component, also rendered under the `/search` URL per the [spec](https://www.figma.com/file/JRTYL35e6a27C3PaP3h4xp/Kirby-UI-v2.0?node-id=182%3A2233)
* Using some fun `react-router` voodoo to allow a key press of `Enter` in the search bar to direct to the new, appropriate `/search` route 
* Small naming refactors for clarity, such as `<SearchModal>` => `<SearchButton>` for the magnifying glass in the App Bar (NOTE: if these cause unnecessary conflicts, they can be removed/reverted for now)
___
* Cleaning up and restructuring as necessary because of the above

