### PR TITLE
fixed the theme-toggle icon positions due to removing the search icon

### DIFF
--- a/src/Components/Scenes/Chrome/AppBar/AppBar.js
+++ b/src/Components/Scenes/Chrome/AppBar/AppBar.js
@@ -12,7 +12,7 @@ const appBarStyle = makeStyles(theme => ({
   },
   themeToggleContainer: {
     position: 'absolute',
-    right: '7px'
+    right: '8px'
   },
   Logo: {
     height: '56px',

--- a/src/Components/Scenes/Chrome/AppBar/AppBar.js
+++ b/src/Components/Scenes/Chrome/AppBar/AppBar.js
@@ -10,14 +10,9 @@ const appBarStyle = makeStyles(theme => ({
     marginLeft: '16px',
     display: 'flex'
   },
-  searchButton: {
-    position: 'absolute',
-    right: '104px',
-    top: '-2px'
-  },
   themeToggleContainer: {
     position: 'absolute',
-    right: '72px'
+    right: '7px'
   },
   Logo: {
     height: '56px',


### PR DESCRIPTION
I just moved the toggle icon back to its original position before I removed the search icon. I also removed some CSS that was for the search icon when it was in the app bar.