### PR TITLE
Removing unnecessary <Splash> and surrounding logic from search results

### DIFF
--- a/src/Components/Scenes/SearchResults/SearchResults/SearchResults-Container.js
+++ b/src/Components/Scenes/SearchResults/SearchResults/SearchResults-Container.js
@@ -7,7 +7,6 @@ import {
 
 const mapStateToProps = ({ searchResult }) => {
   return {
-    searchResultCopy: searchResult.searchResultCopy,
     isLoading: searchResult.isLoading,
     displaySearchResult: searchResult.displaySearchResult
   };

--- a/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
+++ b/src/Components/Scenes/SearchResults/SearchResults/SearchResults.js
@@ -1,12 +1,10 @@
 import React, { useEffect } from 'react';
-import Splash from '../../../Presentational/Splash';
 import TableSectionContainer from '../../SearchResults/TableSection/TableSection-Container';
 import TableSkeleton from '../../SearchResults/TableSkeleton/TableSkeleton';
 import { useQuery } from '../../../../Hooks/customHooks';
 
 const SearchResults = props => {
   const {
-    searchResultCopy,
     isLoading,
     displaySearchResult,
     searchResultPageLoad,
@@ -28,7 +26,6 @@ const SearchResults = props => {
       ) : displaySearchResult ? (
         <TableSectionContainer />
       ) : null}
-      {!searchResultCopy.length ? <Splash /> : null}
     </>
   );
 };


### PR DESCRIPTION
This seems to be an artifact of how we used to structure search pages vs page wrapper.

I know it's not technically in-sprint, but it's basically removing a line and then nuking the vars we don't need. Fixes a frequent visual blip that can be distracting :)