### PR TITLE
Add 500ms delay to menu open interaction

### DIFF
--- a/src/Components/Presentational/Chrome/Navigation.js
+++ b/src/Components/Presentational/Chrome/Navigation.js
@@ -40,7 +40,8 @@ const navStyle = makeStyles(theme => ({
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen
-    })
+    }),
+    transitionDelay: '500ms'
   },
   drawerClose: {
     overflow: 'hidden',

--- a/src/assets/styles/components/Navigation.scss
+++ b/src/assets/styles/components/Navigation.scss
@@ -40,6 +40,7 @@
       width: 48px;
       height: 48px;
       font-size: 14px;
+      transition-delay: 500ms;
     }
   }
 }
@@ -113,6 +114,7 @@
   height: 32px;
   font-size: 8px;
   font-weight: $weight-bold;
+  transition-delay: 0s;
 }
 
 .Nav .Nav__item .Nav__arrow {

--- a/src/assets/styles/components/Navigation.scss
+++ b/src/assets/styles/components/Navigation.scss
@@ -99,6 +99,7 @@
   min-width: 20px;
   margin-right: 1.5rem;
   transition: all 0.2s ease-in-out;
+  transition-delay: 500ms;
 
   & path {
     fill: $color-g-400;


### PR DESCRIPTION
This should make using the navigation a bit less annoying, since it won't accidentally fly open when a user hovers over the icons for a split second.