### PR TITLE
Persist state within a given session

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@material-ui/lab": "^4.0.0-alpha.27",
     "husky": "^3.0.5",
     "lint-staged": "^9.2.5",
+    "lodash": "^4.17.15",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",

--- a/src/State/helpers.js
+++ b/src/State/helpers.js
@@ -25,3 +25,24 @@ export const transformRequests = (requests, role) => {
     }
   });
 };
+
+// Attempts to load in the state from session storage if it's there
+// (https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
+export const loadState = () => {
+  try {
+    const sessionState = sessionStorage.getItem('kirbyState');
+    return sessionState !== null ? JSON.parse(sessionState) : undefined;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+// Persists the state to session storage to avoid losing it on refresh
+export const saveState = state => {
+  try {
+    const sessionState = JSON.stringify(state);
+    sessionStorage.setItem('kirbyState', sessionState);
+  } catch (error) {
+    // Prevents a crash, but state save failures are not critical to handle further
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import './assets/styles/index.scss';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { BrowserRouter as Router } from 'react-router-dom';
-
 import { Provider } from 'react-redux';
 import store from './setupStore';
 

--- a/src/setupStore.js
+++ b/src/setupStore.js
@@ -1,18 +1,28 @@
 import rootReducer from './Reducers';
 import initialState from './Reducers/initialState';
 import rootSaga from './Saga/';
-
 import { createStore, applyMiddleware, compose } from 'redux';
 import createSagaMiddleware from 'redux-saga';
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+import throttle from 'lodash/throttle';
+import { loadState, saveState } from './State/helpers';
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const sagaMiddleware = createSagaMiddleware();
 
 const store = createStore(
   rootReducer,
-  initialState,
+  loadState() || initialState,
   composeEnhancers(applyMiddleware(sagaMiddleware))
 );
 
+// Save the state to session storage upon updates,
+// but cap it at 1Hz :-)
+store.subscribe(
+  throttle(() => {
+    saveState(store.getState());
+  }, 1000)
+);
+
 sagaMiddleware.run(rootSaga);
+
 export default store;


### PR DESCRIPTION
[This video](https://egghead.io/lessons/javascript-redux-persisting-the-state-to-the-local-storage) contains the crux of the logic. While some of our implementation details differ, the takeaways are:
* For now, the plan is to use the `sessionStorage` API. This will persist state as a serialized object in the current window/tab. This is particularly useful for auth, although it could help with plenty of other pain points
* To play around with this, notice how page refreshes behave differently now in redux dev tools (particularly regarding auth). You can also go to the `Application` tab in chrome dev tools to check out `sessionStorage`!
* If we want to extend, change, or limit functionality, it isn't difficult! We probably don't need to store the whole state by the time `Kirby` is ready for MVP, but as a default setting, it works perfectly well

![image](https://user-images.githubusercontent.com/57811960/70574846-4c5b0580-1b62-11ea-97c4-190e39ed255c.png)
