### PR TITLE
Update AppBar styles, make logo clickable (except on home page)

### DIFF
--- a/src/Components/Presentational/Chrome/ThemeToggle.js
+++ b/src/Components/Presentational/Chrome/ThemeToggle.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ReactComponent as LightBulbLight } from '@edma/blocks/src/assets/img/lightbulb-outline.svg';
-import { ReactComponent as LightBulbDark } from '@edma/blocks/src/assets/img/lightbulb.svg';
+import { ReactComponent as LightBulbLight } from '@edma/design-tokens/img/lightbulbOutlineIcon.svg';
+import { ReactComponent as LightBulbDark } from '@edma/design-tokens/img/lightbulbIcon.svg';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { IconButton, Tooltip } from '@material-ui/core';
 import color from '@edma/design-tokens/js/color';

--- a/src/Components/Scenes/Chrome/AppBar/AppBar.js
+++ b/src/Components/Scenes/Chrome/AppBar/AppBar.js
@@ -67,6 +67,15 @@ const Appbar = props => {
   const curPath = useLocation().pathname;
   const { jobName, themeToggle } = props;
 
+  const LogoComponent =
+    curPath === '/' ? (
+      <KirbyLogo className={classes.logo} />
+    ) : (
+      <Link href="/">
+        <KirbyLogo className={classes.logo} />
+      </Link>
+    );
+
   return (
     <AppBar
       position="relative"
@@ -99,12 +108,8 @@ const Appbar = props => {
               <KeyboardArrowDownIcon />
             </Box>
           </>
-        ) : curPath === '/' ? (
-          <KirbyLogo className={classes.logo} />
         ) : (
-          <Link href="/">
-            <KirbyLogo className={classes.logo} />
-          </Link>
+          LogoComponent
         )}
       </div>
       <div className={classes.themeToggleContainer}>

--- a/src/Components/Scenes/Chrome/AppBar/AppBar.js
+++ b/src/Components/Scenes/Chrome/AppBar/AppBar.js
@@ -3,6 +3,7 @@ import ThemeToggle from '../../../Presentational/Chrome/ThemeToggle';
 import { makeStyles } from '@material-ui/core/styles';
 import { AppBar, Box, Breadcrumbs, Link, Typography } from '@material-ui/core';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import { useLocation } from 'react-router-dom';
 import color from '@edma/design-tokens/js/color';
 import { ReactComponent as KirbyLogo } from '../../../../assets/img/kirbyLogo.svg';
 import { ReactComponent as KirbyMark } from '../../../../assets/img/kirbyMark.svg';
@@ -36,12 +37,14 @@ const appBarStyle = makeStyles(theme => ({
     backgroundColor: 'transparent',
     boxShadow: 'none',
     height: 56,
-    marginTop: 32,
+    marginTop: 8,
     transition: 'margin .2s ease-in-out'
+  },
+  appBarHome: {
+    marginTop: 32
   },
   appBarHydration: {
     position: 'absolute',
-    marginTop: 8,
     zIndex: 1,
     width: 'calc(100% - 260px)'
   },
@@ -61,6 +64,7 @@ const appBarStyle = makeStyles(theme => ({
 
 const Appbar = props => {
   const classes = appBarStyle();
+  const curPath = useLocation().pathname;
   const { jobName } = props;
 
   return (
@@ -70,13 +74,17 @@ const Appbar = props => {
       className={
         props.hydration
           ? `${classes.appBar} ${classes.appBarHydration}`
+          : props.home
+          ? `${classes.appBar} ${classes.appBarHome}`
           : classes.appBar
       }
     >
       <div className={classes.logoContainer}>
         {props.hydration ? (
           <>
-            <KirbyMark className={classes.mark} />
+            <Link href="/">
+              <KirbyMark className={classes.mark} />
+            </Link>
             <Box className={classes.header}>
               <Breadcrumbs
                 aria-label="breadcrumb"
@@ -91,8 +99,12 @@ const Appbar = props => {
               <KeyboardArrowDownIcon />
             </Box>
           </>
-        ) : (
+        ) : curPath === '/' ? (
           <KirbyLogo className={classes.logo} />
+        ) : (
+          <Link href="/">
+            <KirbyLogo className={classes.logo} />
+          </Link>
         )}
       </div>
       <div className={classes.themeToggleContainer}>

--- a/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
+++ b/src/Components/Scenes/Chrome/PageWrapper/PageWrapper.js
@@ -39,6 +39,8 @@ const PageWrapper = ({
     <div className={classes.pageContainer}>
       {curPath === '/hydration/new-job' ? (
         <AppBarContainer hydration jobName={newJobName} />
+      ) : curPath === '/' ? (
+        <AppBarContainer home />
       ) : (
         <AppBarContainer />
       )}

--- a/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
+++ b/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
@@ -7,7 +7,11 @@ const styles = makeStyles(theme => ({
     margin: '1rem 0'
   },
   textfield: {
-    width: '100%'
+    width: '100%',
+
+    '& div': {
+      maxWidth: '100%'
+    }
   }
 }));
 

--- a/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
+++ b/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  Button,
+  Grid,
+  MenuItem,
+  Typography,
+  TextField
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const styles = makeStyles(theme => ({
+  gridContainer: {
+    margin: '1rem 0'
+  },
+  textfield: {
+    width: '100%'
+  }
+}));
+
+const NewDestinationForm = props => {
+  const classes = styles();
+
+  return (
+    <>
+      <Typography variant="h2">New Destination</Typography>
+      <Typography variant="body1">
+        New destinations are made available within their respective domains, and
+        can only contain data that matches the declared sensitivity level.
+      </Typography>
+      <Grid container spacing={2} className={classes.gridContainer}>
+        <Grid item xs>
+          <TextField
+            id="name"
+            label="Destination Name"
+            variant="outlined"
+            className={classes.textfield}
+          />
+        </Grid>
+        <Grid item xs>
+          <TextField
+            select
+            id="sensitivity"
+            label="Sensitivity"
+            variant="outlined"
+            helperText="Please select a sensitivity level"
+            className={classes.textfield}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={2} className={classes.gridContainer}>
+        <Grid item xs>
+          <TextField
+            select
+            id="domain"
+            label="Domain"
+            variant="outlined"
+            helperText="Please select a domain"
+            className={classes.textfield}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={2} className={classes.gridContainer}>
+        <Grid item xs>
+          <TextField
+            multiline
+            rows="3"
+            id="description"
+            label="Description"
+            variant="outlined"
+            className={classes.textfield}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={2} className={classes.gridContainer}>
+        <Grid item xs>
+          <TextField
+            multiline
+            rows="3"
+            id="justification"
+            label="Justification"
+            variant="outlined"
+            className={classes.textfield}
+          />
+        </Grid>
+      </Grid>
+      <Grid container justify="flex-end" spacing={2}>
+        <Grid item>
+          <Button variant="contained" color="secondary">
+            Cancel
+          </Button>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" color="primary">
+            Add Destination
+          </Button>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default NewDestinationForm;

--- a/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
+++ b/src/Components/Scenes/Hydration/NewDestination/NewDestination-Form.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Button,
-  Grid,
-  MenuItem,
-  Typography,
-  TextField
-} from '@material-ui/core';
+import { Button, Grid, Typography, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 const styles = makeStyles(theme => ({

--- a/src/Components/Scenes/Hydration/NewDestination/NewDestination.js
+++ b/src/Components/Scenes/Hydration/NewDestination/NewDestination.js
@@ -1,10 +1,26 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import { Paper } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import NewDestinationForm from './NewDestination-Form';
+
+const styles = makeStyles(theme => ({
+  container: {
+    position: 'relative',
+    margin: '0 auto',
+    padding: '2rem',
+    maxWidth: 1200,
+    width: '100%'
+  }
+}));
 
 const NewDestination = props => {
+  const classes = styles();
+
   return (
     <>
-      <Typography type="body1">Hello world.</Typography>
+      <Paper className={classes.container}>
+        <NewDestinationForm />
+      </Paper>
     </>
   );
 };


### PR DESCRIPTION
Logos typically are clickable back to the home page. Now, so is ours! Except if the user is already on the home page, of course.

I also got rid of the arbitrary 32px margin at the top of the AppBar. It's kind of cool on the home page, so I left it there, but it took up important real estate for no reason on the other pages.

I also put together some quick UI for the New Destination page. Feel free to alter as needed. Figured it might save a little time to build out the stateless component.