### PR TITLE
Fix warnings in Schedule Job Form

### DIFF
--- a/src/Components/Scenes/Hydration/App/ScheduleJob/ScheduleJob.tsx
+++ b/src/Components/Scenes/Hydration/App/ScheduleJob/ScheduleJob.tsx
@@ -76,7 +76,7 @@ const ScheduleJob = (props: ScheduleJobProps) => {
         ...scheduleJob.repeats,
         selectedDays: {
           ...scheduleJob.repeats.selectedDays,
-          [name]: event.target.checked
+          [name.toLowerCase()]: event.target.checked
         }
       }
     };
@@ -225,9 +225,9 @@ const ScheduleJob = (props: ScheduleJobProps) => {
               {daysList.map((day: string, i: number) => (
                 <FormControlLabel
                   className="Scheduler__day-checkbox"
+                  key={`${day}-${i}`}
                   control={
                     <Checkbox
-                      key={`${day}-${i}`}
                       checked={scheduleJob.repeats.selectedDays[day]}
                       onChange={e => setSelectedDays(e, day)}
                       value={day}

--- a/src/State/Hydration/forms.ts
+++ b/src/State/Hydration/forms.ts
@@ -58,13 +58,13 @@ export const destinationInitialState = {
 };
 
 export const selectedDaysInitialState = {
-  sunday: false,
-  monday: false,
-  tuesday: false,
-  wednesday: false,
-  thursday: false,
-  friday: false,
-  saturday: false
+  su: false,
+  mo: false,
+  tu: false,
+  we: false,
+  th: false,
+  fr: false,
+  sa: false
 };
 
 export const scheduleJobInitialState = {


### PR DESCRIPTION
Changes to be Merged:
- Fixes the warnings when Weeks/Months is selected in Schedule Job Form
    - fixes the unique keys warning
    - fixes the warning of uncontrolled to controlled input