### PR TITLE
[KIR-419] Conditionals for Hydration Tile Nodes

### DIFF
--- a/src/Components/Scenes/Hydration/App/Destinations/Destinations.tsx
+++ b/src/Components/Scenes/Hydration/App/Destinations/Destinations.tsx
@@ -76,13 +76,17 @@ type DestinationsProps = {
 
 const Destinations = ({ addNodeToDiagram }: DestinationsProps) => {
   const classes = useStyles();
-  const { values } = useFormikContext() as { values: InitialStateTypes };
   const [isSensOpen, setIsSensOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const { destinations } = values;
   const isDestinationModalOpen = useSelector(
     ({ hydration }: any) => hydration.isDestinationModalOpen
   );
   const dispatch = useDispatch();
+
+  const isDestinationAdded = Object.keys(destinations).length > 0;
   const sensitivity = values.destinationsFilterSens;
   const filterInput = document.getElementById('destinationsFilter');
   const filteredDestinations = mockDestinationsData
@@ -194,6 +198,7 @@ const Destinations = ({ addNodeToDiagram }: DestinationsProps) => {
               ({ name, email, description, schedule }, i) => (
                 <ToolbarItemWidget
                   key={`${name}-${i}`}
+                  disabled={isDestinationAdded}
                   model={{
                     type: 'destination',
                     name,

--- a/src/Components/Scenes/Hydration/App/Sources/Sources.tsx
+++ b/src/Components/Scenes/Hydration/App/Sources/Sources.tsx
@@ -1,16 +1,34 @@
 import React from 'react';
 import { color } from '@edma/design-tokens';
+import { useFormikContext } from 'formik';
 import ToolbarItemWidget from '../Toolbar/ToolbarItemWidget';
 import mockSourcesData from '../../../../../State/__mockData__/mockSourcesMetadata.json'; // TODO: replace mockdata
-import { AddNodeToDiagram } from '../../../../../State/Hydration/types';
+import {
+  AddNodeToDiagram,
+  InitialStateTypes
+} from '../../../../../State/Hydration/types';
 
 type SourcesProps = {
   addNodeToDiagram: AddNodeToDiagram;
 };
 
 const Sources = ({ addNodeToDiagram }: SourcesProps) => {
-  const sourceItems = Object.entries(mockSourcesData).map(source => ({
-    sourceType: source[0]
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const { sources } = values;
+  const { transforms } = values;
+
+  const isKirbySourceAdded = Boolean(
+    Object.values(sources).find(source => source.sourceType === 'KIRBY')
+  );
+  const isNonKirbySourceAdded =
+    Object.values(sources).length > 0 && !isKirbySourceAdded;
+  const isTransformAdded = Object.values(transforms).length > 0;
+  // TODO: below is based on mock data; will need to change based on real data
+  const sourceItems = Object.keys(mockSourcesData).map(source => ({
+    sourceType: source,
+    disabled:
+      (source !== 'KIRBY' && (isKirbySourceAdded || isTransformAdded)) ||
+      (source === 'KIRBY' && isNonKirbySourceAdded)
   }));
 
   return (
@@ -18,6 +36,7 @@ const Sources = ({ addNodeToDiagram }: SourcesProps) => {
       {sourceItems.map((source, i) => (
         <ToolbarItemWidget
           key={`${source.sourceType}-${i}`}
+          disabled={source.disabled}
           model={{ type: 'source', name: source.sourceType }}
           name={source.sourceType}
           color={color['c400']}

--- a/src/Components/Scenes/Hydration/App/Toolbar/Toolbar.tsx
+++ b/src/Components/Scenes/Hydration/App/Toolbar/Toolbar.tsx
@@ -42,6 +42,7 @@ const Toolbar = ({
   if (selectedNode) {
     return (
       <ToolbarWidget
+        setTab={setTab}
         tab={tab}
         handleTabsChange={handleTabsChange}
         setIsScheduleJobOpen={setIsScheduleJobOpen}
@@ -71,6 +72,7 @@ const Toolbar = ({
 
   return (
     <ToolbarWidget
+      setTab={setTab}
       tab={tab}
       handleTabsChange={handleTabsChange}
       setIsScheduleJobOpen={setIsScheduleJobOpen}

--- a/src/Components/Scenes/Hydration/App/Toolbar/ToolbarItemWidget.tsx
+++ b/src/Components/Scenes/Hydration/App/Toolbar/ToolbarItemWidget.tsx
@@ -9,6 +9,7 @@ import DestIconDark from '../../../../../assets/img/icon.hydration.dest.dark.svg
 import { NodeModel } from '../../../../../State/Hydration/types';
 
 interface ToolbarItemWidget {
+  disabled?: boolean | null;
   name: string;
   onClick: () => NodeModel;
   color: string;
@@ -16,6 +17,7 @@ interface ToolbarItemWidget {
 }
 
 const ToolbarItemWidget = ({
+  disabled = false,
   name,
   color,
   model,
@@ -44,16 +46,25 @@ const ToolbarItemWidget = ({
   return (
     <div
       style={{ borderColor: color }}
-      draggable={true}
-      onDragStart={event => {
-        event.dataTransfer.setData('storm-diagram-node', JSON.stringify(model));
-      }}
-      className="Toolbar__nodetype"
-      onClick={onClick}
+      draggable={!disabled}
+      onDragStart={
+        disabled
+          ? undefined
+          : event => {
+              event.dataTransfer.setData(
+                'storm-diagram-node',
+                JSON.stringify(model)
+              );
+            }
+      }
+      className={disabled ? 'Toolbar__nodetype-disabled' : 'Toolbar__nodetype'}
+      onClick={disabled ? undefined : onClick}
     >
       <img
         src={theme.palette.type === 'light' ? modelType : modelTypeDark}
-        className={`Toolbar__item-icon`}
+        className={
+          disabled ? 'Toolbar__item-icon-disabled' : 'Toolbar__item-icon'
+        }
         alt={`${name} icon`}
       />{' '}
       {name}

--- a/src/Components/Scenes/Hydration/App/Toolbar/ToolbarWidget.tsx
+++ b/src/Components/Scenes/Hydration/App/Toolbar/ToolbarWidget.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useFormikContext } from 'formik';
 import { IconButton, Tab, Tabs, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import UndoIcon from '@material-ui/icons/Undo';
@@ -8,6 +9,7 @@ import StopIcon from '@material-ui/icons/Stop';
 import ScheduleIcon from '@material-ui/icons/Schedule';
 import PublishIcon from '@material-ui/icons/Publish';
 import color from '@edma/design-tokens/js/color';
+import { InitialStateTypes } from '../../../../../State/Hydration/types';
 
 const useStyles = makeStyles(theme => ({
   toolbar: {
@@ -26,6 +28,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 interface ToolbarWidgetProps {
+  setTab: (num: number) => void;
   tab: number;
   handleTabsChange: (_: any, newTab: number) => void;
   setIsScheduleJobOpen: (value: boolean) => void;
@@ -33,6 +36,7 @@ interface ToolbarWidgetProps {
 }
 
 const ToolbarWidget = ({
+  setTab,
   tab,
   handleTabsChange,
   setIsScheduleJobOpen,
@@ -40,6 +44,20 @@ const ToolbarWidget = ({
 }: ToolbarWidgetProps) => {
   const classes = useStyles();
   const [isJobRunning, setIsJobRunning] = useState(false);
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const { sources } = values;
+
+  const isNonKirbySourceAdded = Boolean(
+    Object.values(sources).find(source =>
+      ['RDBMS', 'SFTP', 'API'].includes(source.sourceType)
+    )
+  );
+
+  useEffect(() => {
+    if (isNonKirbySourceAdded) {
+      setTab(2);
+    }
+  }, [isNonKirbySourceAdded, setTab]);
 
   return (
     <div className={`${classes.toolbar} Toolbar`}>
@@ -131,8 +149,16 @@ const ToolbarWidget = ({
           onChange={handleTabsChange}
           aria-label="Tile types"
         >
-          <Tab label="Sources" className="Toolbar__sources-tab" />
-          <Tab label="Transforms" className="Toolbar__transforms-tab" />
+          <Tab
+            disabled={isNonKirbySourceAdded}
+            label="Sources"
+            className="Toolbar__sources-tab"
+          />
+          <Tab
+            disabled={isNonKirbySourceAdded}
+            label="Transforms"
+            className="Toolbar__transforms-tab"
+          />
           <Tab label="Destinations" className="Toolbar__destinations-tab" />
         </Tabs>
       </div>

--- a/src/State/Hydration/forms.ts
+++ b/src/State/Hydration/forms.ts
@@ -40,15 +40,6 @@ export const apiInitialState = {
   connectionType: ''
 };
 
-export const kirbyInitialState = {
-  sourceType: null,
-  host: '',
-  port: '',
-  folder: '',
-  isConnected: false,
-  connectionType: ''
-};
-
 export const transformInitialState = {
   name: '',
   sqlScript: '',
@@ -117,8 +108,6 @@ export const generateSourceInitialState = (
     sourceForm = sftpInitialState;
   } else if (sourceType === 'API') {
     sourceForm = apiInitialState;
-  } else if (sourceType === 'KIRBY') {
-    sourceForm = kirbyInitialState;
   }
 
   return {

--- a/src/State/Hydration/forms.ts
+++ b/src/State/Hydration/forms.ts
@@ -40,6 +40,15 @@ export const apiInitialState = {
   connectionType: ''
 };
 
+export const kirbyInitialState = {
+  sourceType: null,
+  host: '',
+  port: '',
+  folder: '',
+  isConnected: false,
+  connectionType: ''
+};
+
 export const transformInitialState = {
   name: '',
   sqlScript: '',
@@ -108,6 +117,8 @@ export const generateSourceInitialState = (
     sourceForm = sftpInitialState;
   } else if (sourceType === 'API') {
     sourceForm = apiInitialState;
+  } else if (sourceType === 'KIRBY') {
+    sourceForm = kirbyInitialState;
   }
 
   return {

--- a/src/State/Hydration/types.ts
+++ b/src/State/Hydration/types.ts
@@ -17,6 +17,7 @@ export interface KIRBY {
 }
 
 export interface RDBMS {
+  sourceType: string;
   sourceVersion: string;
   server: string;
   schema: string;

--- a/src/assets/styles/components/Toolbar.scss
+++ b/src/assets/styles/components/Toolbar.scss
@@ -86,6 +86,19 @@
   }
 }
 
+.Toolbar__nodetype-disabled {
+  padding: 8px 16px;
+  margin-bottom: 2px;
+  cursor: pointer;
+  text-align: left;
+  color: $color-g-100;
+
+  &:hover {
+    background: $color-g-100;
+    color: $color-black;
+  }
+}
+
 .dark .Toolbar__nodetype {
   color: $color-g-400;
 
@@ -102,6 +115,12 @@
 .Toolbar__item-icon {
   width: 21px;
   margin-right: 4px;
+}
+
+.Toolbar__item-icon-disabled {
+  width: 21px;
+  margin-right: 4px;
+  color: $color-g-100;
 }
 
 .Toolbar__list {


### PR DESCRIPTION
Changes to be Merged:
- When Source type Kirby is added to the diagram, disable the ability of adding the other sources
- When a Non Kirby Source Type is added (ie. RDBMS, SFTP, API) to the diagram, disable the ability of adding Source type Kirby AND disable the Transforms Tab
- When adding a Transforms Tile, disable Non Kirby Source Types
- When adding a Destinations Tile, disable all the other destinations list

Note:
- This does not include Snackbar Notifications for adding Tiles
- This does not include the prevention of connecting between Kirby Source and Destination
- classes: `.Toolbar__item-icon-disabled`  and `.Toolbar__nodetype-disabled` are the classes used for adding disabled styling; naming and the styling is up for change