### PR TITLE
Provide Different Configurations for Arrowheads based on Type

### DIFF
--- a/src/Components/Scenes/Hydration/App/Links/ArrowHead.js
+++ b/src/Components/Scenes/Hydration/App/Links/ArrowHead.js
@@ -1,13 +1,14 @@
 import React from 'react';
 
-export const markerHead = 'markerHead';
+export const sourceHead = 'sourceHead';
+export const transformHead = 'transformHead';
 
 const ArrowHead = () => {
   return (
     <svg>
       <defs>
         <marker
-          id={markerHead}
+          id={sourceHead}
           markerWidth="6"
           markerHeight="4"
           refX="3"
@@ -15,6 +16,16 @@ const ArrowHead = () => {
           orient="0deg"
         >
           <path d="M0,0 L0,4 L4,2 Z" style={{ fill: 'orange' }} />
+        </marker>
+        <marker
+          id={transformHead}
+          markerWidth="6"
+          markerHeight="4"
+          refX="3"
+          refY="2"
+          orient="0deg"
+        >
+          <path d="M0,0 L0,4 L4,2 Z" style={{ fill: 'pink' }} />
         </marker>
       </defs>
     </svg>

--- a/src/Components/Scenes/Hydration/App/Links/SourceLinkSegment.js
+++ b/src/Components/Scenes/Hydration/App/Links/SourceLinkSegment.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import { markerHead } from '../Links/ArrowHead';
+import { sourceHead } from '../Links/ArrowHead';
 import { createCustomPath } from './helpers';
 
 // TODO: convert to functional component if possible
 class SourceLinkSegment extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.style = { markerEnd: `url(#${markerHead})` };
+    this.style = { markerEnd: `url(#${sourceHead})` };
   }
 
   componentDidUpdate = prevProps => {
     if (prevProps.inversed !== this.props.inversed) {
-      this.style = { markerEnd: `url(#${markerHead})` };
+      this.style = { markerEnd: `url(#${sourceHead})` };
     }
   };
 

--- a/src/Components/Scenes/Hydration/App/Links/TransformLinkSegment.js
+++ b/src/Components/Scenes/Hydration/App/Links/TransformLinkSegment.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import { markerHead } from '../Links/ArrowHead';
+import { transformHead } from '../Links/ArrowHead';
 import { createCustomPath } from './helpers';
 
 // TODO: convert to functional component if possible
 class TransformLinkSegment extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.style = { markerEnd: `url(#${markerHead})` };
+    this.style = { markerEnd: `url(#${transformHead})` };
   }
 
   componentDidUpdate = prevProps => {
     if (prevProps.inversed !== this.props.inversed) {
-      this.style = { markerEnd: `url(#${markerHead})` };
+      this.style = { markerEnd: `url(#${transformHead})` };
     }
   };
 


### PR DESCRIPTION
Changes to be merged:
- Provide Different Configurations for Arrowheads based on Type

_NOTE:_
- 2 different types of markers, they can be configured by adding a class on the maker html