### PR TITLE
[KIR-461] Connection Button Functionality

### DIFF
--- a/src/Components/Scenes/Hydration/App/Source/Api.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Api.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import {
   Button,
   FormControl,
@@ -10,12 +10,16 @@ import {
   TextField,
   Tooltip,
   Select,
-  Divider
+  Divider,
+  CircularProgress
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import FlashOnIcon from '@material-ui/icons/FlashOn';
-import { NodeModel } from '../../../../../State/Hydration/types';
+import {
+  NodeModel,
+  InitialStateTypes
+} from '../../../../../State/Hydration/types';
 import mockSourcesMetadata from '../../../../../State/__mockData__/mockSourcesMetadata.json';
 
 interface ApiProps {
@@ -32,6 +36,15 @@ const useStyles = makeStyles(theme => ({
   },
   selectFormControl: {
     display: 'flex'
+  },
+  colorForSuccess: {
+    color: 'green'
+  },
+  colorForFail: {
+    color: 'red'
+  },
+  hide: {
+    display: 'none'
   }
 }));
 
@@ -42,7 +55,18 @@ const Rdbms = (props: ApiProps) => {
     ({ hydration }: any) => hydration.selectedNode
   );
   const classes = useStyles();
-
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const [isCalling, setIsCalling] = useState(false);
+  const [isCallSuccessful, setIsCallSuccessful] = useState(false);
+  const [isCallFail, setIsCallFail] = useState(false);
+  const sourceTilesTypeConnection = () => {
+    setIsCalling(true);
+    return setTimeout(function() {
+      setIsCalling(false);
+      setIsCallFail(false);
+      setIsCallSuccessful(true);
+    }, 4000);
+  };
   return (
     <div className="Toolbar__container">
       <div className="Toolbar__section">
@@ -104,12 +128,34 @@ const Rdbms = (props: ApiProps) => {
       <Divider className={classes.divider} />
 
       <div className="Toolbar__section">
-        <Tooltip title="Not Connected" placement="top">
-          <FlashOnIcon className="Toolbar__bolt-icon" />
+        <Tooltip
+          title={
+            isCallSuccessful
+              ? 'Connected'
+              : isCallFail
+              ? 'Unable to connect'
+              : 'Not Connected'
+          }
+          placement="top"
+        >
+          {isCalling ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <FlashOnIcon
+              className={
+                isCallSuccessful
+                  ? classes.colorForSuccess
+                  : isCallFail
+                  ? classes.colorForFail
+                  : 'Toolbar__bolt-icon'
+              }
+            />
+          )}
         </Tooltip>
         <h4 className={`Toolbar__form-title`}>Connection</h4>
         <FormControl
           className={`Input__select Toolbar__connection-type ${classes.selectFormControl}`}
+          disabled={isCalling}
         >
           <InputLabel id="connection-type">Type</InputLabel>
           <Field
@@ -126,7 +172,15 @@ const Rdbms = (props: ApiProps) => {
             ))}
           </Field>
         </FormControl>
-        <Button variant="outlined" color="primary" className="Tile__button">
+        <Button
+          variant="outlined"
+          color="primary"
+          className={isCallSuccessful ? classes.hide : 'Tile__button'}
+          disabled={
+            !Object.values(values.sources)[0].connectionType || isCalling
+          }
+          onClick={sourceTilesTypeConnection}
+        >
           Test Connection
         </Button>
       </div>

--- a/src/Components/Scenes/Hydration/App/Source/Api.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Api.tsx
@@ -59,6 +59,7 @@ const Rdbms = (props: ApiProps) => {
   const [isCalling, setIsCalling] = useState(false);
   const [isCallSuccessful, setIsCallSuccessful] = useState(false);
   const [isCallFail, setIsCallFail] = useState(false);
+  // TODO replace with real API call
   const sourceTilesTypeConnection = () => {
     setIsCalling(true);
     return setTimeout(function() {

--- a/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
@@ -59,6 +59,7 @@ const Kirby = (props: KirbyProps) => {
   const [isCalling, setIsCalling] = useState(false);
   const [isCallSuccessful, setIsCallSuccessful] = useState(false);
   const [isCallFail, setIsCallFail] = useState(false);
+  // TODO replace with real api call
   const sourceTilesTypeConnection = () => {
     setIsCalling(true);
     return setTimeout(function() {

--- a/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
@@ -36,6 +36,15 @@ const useStyles = makeStyles(theme => ({
   },
   selectFormControl: {
     display: 'flex'
+  },
+  colorForSuccess: {
+    color: 'green'
+  },
+  colorForFail: {
+    color: 'red'
+  },
+  hide: {
+    display: 'none'
   }
 }));
 
@@ -48,11 +57,14 @@ const Kirby = (props: KirbyProps) => {
   const classes = useStyles();
   const { values } = useFormikContext() as { values: InitialStateTypes };
   const [isCalling, setIsCalling] = useState(false);
-
+  const [isCallSuccessful, setIsCallSuccessful] = useState(false);
+  const [isCallFail, setIsCallFail] = useState(false);
   const sourceTilesTypeConnection = () => {
     setIsCalling(true);
     return setTimeout(function() {
       setIsCalling(false);
+      setIsCallFail(false);
+      setIsCallSuccessful(true);
     }, 4000);
   };
   return (
@@ -91,11 +103,28 @@ const Kirby = (props: KirbyProps) => {
       <Divider className={classes.divider} />
 
       <div className="Toolbar__section">
-        <Tooltip title="Not Connected" placement="top">
+        <Tooltip
+          title={
+            isCallSuccessful
+              ? 'Connected'
+              : isCallFail
+              ? 'Unable to connect'
+              : 'Not Connected'
+          }
+          placement="top"
+        >
           {isCalling ? (
-            <CircularProgress />
+            <CircularProgress size={24} color="inherit" />
           ) : (
-            <FlashOnIcon className="Toolbar__bolt-icon" />
+            <FlashOnIcon
+              className={
+                isCallSuccessful
+                  ? classes.colorForSuccess
+                  : isCallFail
+                  ? classes.colorForFail
+                  : 'Toolbar__bolt-icon'
+              }
+            />
           )}
         </Tooltip>
         <h4 className={`Toolbar__form-title`}>Connection</h4>
@@ -121,7 +150,7 @@ const Kirby = (props: KirbyProps) => {
         <Button
           variant="outlined"
           color="primary"
-          className="Tile__button"
+          className={isCallSuccessful ? classes.hide : 'Tile__button'}
           disabled={
             !Object.values(values.sources)[0].connectionType || isCalling
           }

--- a/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Kirby.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import {
   Button,
   FormControl,
@@ -10,12 +10,16 @@ import {
   TextField,
   Tooltip,
   Select,
-  Divider
+  Divider,
+  CircularProgress
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import FlashOnIcon from '@material-ui/icons/FlashOn';
-import { NodeModel } from '../../../../../State/Hydration/types';
+import {
+  NodeModel,
+  InitialStateTypes
+} from '../../../../../State/Hydration/types';
 import mockSourcesMetadata from '../../../../../State/__mockData__/mockSourcesMetadata.json';
 
 interface KirbyProps {
@@ -42,7 +46,15 @@ const Kirby = (props: KirbyProps) => {
   );
   const { KIRBY } = mockSourcesMetadata; // TODO: replace with real data
   const classes = useStyles();
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const [isCalling, setIsCalling] = useState(false);
 
+  const sourceTilesTypeConnection = () => {
+    setIsCalling(true);
+    return setTimeout(function() {
+      setIsCalling(false);
+    }, 4000);
+  };
   return (
     <div className="Toolbar__container">
       <div className="Toolbar__section">
@@ -80,11 +92,16 @@ const Kirby = (props: KirbyProps) => {
 
       <div className="Toolbar__section">
         <Tooltip title="Not Connected" placement="top">
-          <FlashOnIcon className="Toolbar__bolt-icon" />
+          {isCalling ? (
+            <CircularProgress />
+          ) : (
+            <FlashOnIcon className="Toolbar__bolt-icon" />
+          )}
         </Tooltip>
         <h4 className={`Toolbar__form-title`}>Connection</h4>
         <FormControl
           className={`Input__select Toolbar__connection-type ${classes.selectFormControl}`}
+          disabled={isCalling}
         >
           <InputLabel id="connection-type">Type</InputLabel>
           <Field
@@ -101,7 +118,15 @@ const Kirby = (props: KirbyProps) => {
             ))}
           </Field>
         </FormControl>
-        <Button variant="outlined" color="primary" className="Tile__button">
+        <Button
+          variant="outlined"
+          color="primary"
+          className="Tile__button"
+          disabled={
+            !Object.values(values.sources)[0].connectionType || isCalling
+          }
+          onClick={sourceTilesTypeConnection}
+        >
           Test Connection
         </Button>
       </div>

--- a/src/Components/Scenes/Hydration/App/Source/Rdbms.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Rdbms.tsx
@@ -59,6 +59,7 @@ const Rdbms = (props: RdbmsProps) => {
   const [isCalling, setIsCalling] = useState(false);
   const [isCallSuccessful, setIsCallSuccessful] = useState(false);
   const [isCallFail, setIsCallFail] = useState(false);
+  // TODO replace with real API call
   const sourceTilesTypeConnection = () => {
     setIsCalling(true);
     return setTimeout(function() {

--- a/src/Components/Scenes/Hydration/App/Source/Rdbms.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Rdbms.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import {
   Button,
   FormControl,
@@ -10,12 +10,16 @@ import {
   TextField,
   Tooltip,
   Select,
-  Divider
+  Divider,
+  CircularProgress
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import FlashOnIcon from '@material-ui/icons/FlashOn';
-import { NodeModel } from '../../../../../State/Hydration/types';
+import {
+  NodeModel,
+  InitialStateTypes
+} from '../../../../../State/Hydration/types';
 import mockSourcesMetadata from '../../../../../State/__mockData__/mockSourcesMetadata.json';
 
 interface RdbmsProps {
@@ -32,6 +36,15 @@ const useStyles = makeStyles(theme => ({
   },
   selectFormControl: {
     display: 'flex'
+  },
+  colorForSuccess: {
+    color: 'green'
+  },
+  colorForFail: {
+    color: 'red'
+  },
+  hide: {
+    display: 'none'
   }
 }));
 
@@ -42,6 +55,18 @@ const Rdbms = (props: RdbmsProps) => {
     ({ hydration }: any) => hydration.selectedNode
   );
   const classes = useStyles();
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const [isCalling, setIsCalling] = useState(false);
+  const [isCallSuccessful, setIsCallSuccessful] = useState(false);
+  const [isCallFail, setIsCallFail] = useState(false);
+  const sourceTilesTypeConnection = () => {
+    setIsCalling(true);
+    return setTimeout(function() {
+      setIsCalling(false);
+      setIsCallFail(false);
+      setIsCallSuccessful(true);
+    }, 4000);
+  };
 
   return (
     <div className="Toolbar__container">
@@ -98,12 +123,34 @@ const Rdbms = (props: RdbmsProps) => {
       <Divider className={classes.divider} />
 
       <div className="Toolbar__section">
-        <Tooltip title="Not Connected" placement="top">
-          <FlashOnIcon className="Toolbar__bolt-icon" />
+        <Tooltip
+          title={
+            isCallSuccessful
+              ? 'Connected'
+              : isCallFail
+              ? 'Unable to connect'
+              : 'Not Connected'
+          }
+          placement="top"
+        >
+          {isCalling ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <FlashOnIcon
+              className={
+                isCallSuccessful
+                  ? classes.colorForSuccess
+                  : isCallFail
+                  ? classes.colorForFail
+                  : 'Toolbar__bolt-icon'
+              }
+            />
+          )}
         </Tooltip>
         <h4 className={`Toolbar__form-title`}>Connection</h4>
         <FormControl
           className={`${classes.selectFormControl} Input__select Toolbar__connection-type`}
+          disabled={isCalling}
         >
           <InputLabel id="connection-type">Type</InputLabel>
           <Field
@@ -120,7 +167,15 @@ const Rdbms = (props: RdbmsProps) => {
             ))}
           </Field>
         </FormControl>
-        <Button variant="outlined" color="primary" className="Tile__button">
+        <Button
+          variant="outlined"
+          color="primary"
+          className={isCallSuccessful ? classes.hide : 'Tile__button'}
+          disabled={
+            !Object.values(values.sources)[0].connectionType || isCalling
+          }
+          onClick={sourceTilesTypeConnection}
+        >
           Test Connection
         </Button>
       </div>

--- a/src/Components/Scenes/Hydration/App/Source/Sftp.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Sftp.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import {
   Button,
   FormControl,
@@ -10,12 +10,16 @@ import {
   TextField,
   Tooltip,
   Select,
-  Divider
+  Divider,
+  CircularProgress
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import FlashOnIcon from '@material-ui/icons/FlashOn';
-import { NodeModel } from '../../../../../State/Hydration/types';
+import {
+  NodeModel,
+  InitialStateTypes
+} from '../../../../../State/Hydration/types';
 import mockSourcesMetadata from '../../../../../State/__mockData__/mockSourcesMetadata.json';
 
 interface SftpProps {
@@ -32,6 +36,15 @@ const useStyles = makeStyles(theme => ({
   },
   selectFormControl: {
     display: 'flex'
+  },
+  colorForSuccess: {
+    color: 'green'
+  },
+  colorForFail: {
+    color: 'red'
+  },
+  hide: {
+    display: 'none'
   }
 }));
 
@@ -42,7 +55,18 @@ const Sftp = (props: SftpProps) => {
   );
   const { SFTP } = mockSourcesMetadata; // TODO: replace with real data
   const classes = useStyles();
-
+  const { values } = useFormikContext() as { values: InitialStateTypes };
+  const [isCalling, setIsCalling] = useState(false);
+  const [isCallSuccessful, setIsCallSuccessful] = useState(false);
+  const [isCallFail, setIsCallFail] = useState(false);
+  const sourceTilesTypeConnection = () => {
+    setIsCalling(true);
+    return setTimeout(function() {
+      setIsCalling(false);
+      setIsCallFail(false);
+      setIsCallSuccessful(true);
+    }, 4000);
+  };
   return (
     <div className="Toolbar__container">
       <div className="Toolbar__section">
@@ -79,12 +103,34 @@ const Sftp = (props: SftpProps) => {
       <Divider className={classes.divider} />
 
       <div className="Toolbar__section">
-        <Tooltip title="Not Connected" placement="top">
-          <FlashOnIcon className="Toolbar__bolt-icon" />
+        <Tooltip
+          title={
+            isCallSuccessful
+              ? 'Connected'
+              : isCallFail
+              ? 'Unable to connect'
+              : 'Not Connected'
+          }
+          placement="top"
+        >
+          {isCalling ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <FlashOnIcon
+              className={
+                isCallSuccessful
+                  ? classes.colorForSuccess
+                  : isCallFail
+                  ? classes.colorForFail
+                  : 'Toolbar__bolt-icon'
+              }
+            />
+          )}
         </Tooltip>
         <h4 className={`Toolbar__form-title`}>Connection</h4>
         <FormControl
           className={`Input__select Toolbar__connection-type ${classes.selectFormControl}`}
+          disabled={isCalling}
         >
           <InputLabel id="connection-type">Type</InputLabel>
           <Field
@@ -101,7 +147,15 @@ const Sftp = (props: SftpProps) => {
             ))}
           </Field>
         </FormControl>
-        <Button variant="outlined" color="primary" className="Tile__button">
+        <Button
+          variant="outlined"
+          color="primary"
+          className={isCallSuccessful ? classes.hide : 'Tile__button'}
+          disabled={
+            !Object.values(values.sources)[0].connectionType || isCalling
+          }
+          onClick={sourceTilesTypeConnection}
+        >
           Test Connection
         </Button>
       </div>

--- a/src/Components/Scenes/Hydration/App/Source/Sftp.tsx
+++ b/src/Components/Scenes/Hydration/App/Source/Sftp.tsx
@@ -59,6 +59,7 @@ const Sftp = (props: SftpProps) => {
   const [isCalling, setIsCalling] = useState(false);
   const [isCallSuccessful, setIsCallSuccessful] = useState(false);
   const [isCallFail, setIsCallFail] = useState(false);
+  // TODO replace with real Api call
   const sourceTilesTypeConnection = () => {
     setIsCalling(true);
     return setTimeout(function() {

--- a/src/State/__mockData__/mockSourcesMetadata.json
+++ b/src/State/__mockData__/mockSourcesMetadata.json
@@ -1,6 +1,6 @@
 {
   "KIRBY": {
-    "connectionTypes": ["AWS Glue"]
+    "connectionTypes": ["SFTP", "AWS Glue"]
   },
   "RDBMS": {
     "sourceVersions": ["MySQL", "MSSQL"],


### PR DESCRIPTION
[[https://edma.atlassian.net/browse/KIR-461]](url)
Things to be Merged

- The “Test Connection” button is disabled by default
- [x] When a user selects a connection type for a source tile, the “Test Connection” button becomes enabled
- When a user clicks on the “Test Connection” button and it is enabled:
- [x] The BoltIcon should be replaced with <Progress variant=”circular” color=”primary” />
- [ ] A Snackbar should be displayed in the bottom right corner that says, “Testing {sourceType} connection” for the duration of the test, where {sourceType} equals the source type of the selected tile.
- [x] The “Test Connection” button should be disabled
- [x] The “Type” select menu should be disabled
- When a Connection tests successfully:
- [x] The “Test Connection” button should be hidden
- [x] The Progress should be removed
- [x] The BoltIcon should be displayed and colored green 500
 - [x] The BoltIcon should have a Tooltip that says, “Connected” on hover
 - [ ] A Snackbar should be displayed that says, “Successfully connected to {sourceType}!” where {sourceType} equals the source type of the tested tile
- When a Connection fails:
- [x] The “Test Connection” button should be enabled
- [x] The Progress should be removed
- [x] The BoltIcon should be displayed and colored red 600
- [x] The BoltIcon should have a Tooltip that says, “Unable to connect” on hover
- [ ] The selected Source tile should be displayed in its error state
- [ ] A WarningIcon should be displayed on the selected Source tile, and colored red 600
- [ ] The WarningIcon should have a Tooltip that says, “Unable to connect” on hover
- [ ] A Snackbar should be displayed that says, “Unable to connect to {sourceType}.” where {sourceType} equals the source type of the tested tile

 
NOTE:

- I might need some CSS help.
- All Snackbar / Node State will be added once Ed done with his work.