### PR TITLE
[KIR-467] Set Tile as Selected when Adding Tile to Diagram

### DIFF
--- a/src/Components/Scenes/Hydration/App/JobDesigner/JobDesigner.tsx
+++ b/src/Components/Scenes/Hydration/App/JobDesigner/JobDesigner.tsx
@@ -98,6 +98,8 @@ const JobDesigner = (props: JobDesignerProps) => {
         dispatch(setSelectedNode(null))
     });
 
+    node.selected = true;
+    dispatch(setSelectedNode(null, node));
     forceUpdate();
     return node;
   };


### PR DESCRIPTION
Changes to be Merged:
- when adding node to diagram, the node tile should be selected by default